### PR TITLE
Add content encoding support, add new GrpcWebJsonWithZipsonCodec

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "lodash": "^4.17.5",
     "moment": "^2.14.1",
     "node-jose": "^1.0.0",
-    "query-string": "^6.0.0"
+    "query-string": "^6.0.0",
+    "zipson": "^0.2.12"
   },
   "devDependencies": {
     "@improbable-eng/grpc-web-node-http-transport": "^0.11.0",

--- a/src/protocol/grpc_web/__tests__/client_server.it.ts
+++ b/src/protocol/grpc_web/__tests__/client_server.it.ts
@@ -712,6 +712,10 @@ class InvalidCodec implements GrpcWebCodec {
     return this.codec.getContentType();
   }
 
+  getContentEncoding() {
+    return this.codec.getContentEncoding();
+  }
+
   /** @override */
   encodeMessage(_method: string, _payload: any): Uint8Array {
     return encodeUtf8('__invalid_json__');

--- a/src/protocol/grpc_web/client/client.ts
+++ b/src/protocol/grpc_web/client/client.ts
@@ -284,6 +284,7 @@ class GrpcWebStream<Request, Response, ResponseContext>
           new grpc.Metadata({
             'content-type': this.codec.getContentType(),
             accept: this.codec.getContentType(),
+            'Content-Encoding': this.codec.getContentEncoding(),
             'x-user-agent': 'grpc-web-javascript/0.1',
             ...requestContext,
           }),

--- a/src/protocol/grpc_web/common/codec.ts
+++ b/src/protocol/grpc_web/common/codec.ts
@@ -25,6 +25,11 @@ export interface GrpcWebCodec<Message = any> {
    */
   getContentType(): string;
 
+  /**
+   * Returns the content encodings to put as HTTP headers for content negotiation.
+   */
+  getContentEncoding(): string;
+
   /** Encodes a request for the RPC method `method`. */
   encodeRequest(method: string, message: Message): Uint8Array;
 

--- a/src/protocol/grpc_web/common/json_codec.ts
+++ b/src/protocol/grpc_web/common/json_codec.ts
@@ -12,7 +12,7 @@
 import { GrpcWebCodec } from './codec';
 import { decodeUtf8, encodeUtf8 } from '../private/utf8';
 import { grpc } from '@improbable-eng/grpc-web';
-
+import { stringify, parse } from 'zipson';
 /**
  * Line separator between the entries of the trailer metadata (as required by
  * the gRPC-Web specification).
@@ -26,6 +26,10 @@ export class GrpcWebJsonCodec implements GrpcWebCodec {
   /** @override */
   getContentType() {
     return 'application/grpc-web+json';
+  }
+
+  getContentEncoding() {
+    return 'identity';
   }
 
   /** @override */
@@ -75,5 +79,68 @@ export class GrpcWebJsonCodec implements GrpcWebCodec {
       throw new Error("a payload cannot be 'undefined'");
     }
     return encodeUtf8(JSON.stringify(payload));
+  }
+}
+
+/**
+ * A Codec that serializes/deserializes messages to and from JSON.
+ */
+ export class GrpcWebJsonWithZipsonCodec implements GrpcWebCodec {
+  /** @override */
+  getContentType() {
+    return 'application/grpc-web+json';
+  }
+
+  getContentEncoding() {
+    return 'zipson';
+  }
+
+  /** @override */
+  encodeMessage(_method: string, payload: any): Uint8Array {
+    return this.encode(payload);
+  }
+
+  /** @override */
+  encodeTrailer(metadata: grpc.Metadata): Uint8Array {
+    const headers: string[] = [];
+    for (const key in metadata.headersMap) {
+      const values = metadata.headersMap[key];
+      for (const value of values) {
+        const trimmedValue = value.trim();
+        if (!trimmedValue) continue;
+        headers.push(`${key}: ${trimmedValue}`);
+      }
+    }
+    return encodeUtf8(headers.join(CLRF));
+  }
+
+  /** @override */
+  encodeRequest(_method: string, message: any): Uint8Array {
+    return this.encode(message);
+  }
+
+  /** @override */
+  decodeRequest(_method: string, message: Uint8Array): any {
+    return parse(decodeUtf8(message));
+  }
+
+  /** @override */
+  decodeMessage(_method: string, encodedMessage: Uint8Array): any {
+    return parse(decodeUtf8(encodedMessage));
+  }
+
+  /** @override */
+  decodeTrailer(encodedTrailer: Uint8Array): grpc.Metadata {
+    return new grpc.Metadata(decodeUtf8(encodedTrailer));
+  }
+
+  private encode(payload: any): Uint8Array {
+    if (payload === undefined) {
+      // We need to single out undefined payloads as
+      // JSON.stringify(undefined) === undefined (and so it is not
+      // a string that can be UTF-8 encoded).
+      throw new Error("a payload cannot be 'undefined'");
+    }
+    return encodeUtf8(stringify(payload));
   }
 }

--- a/src/protocol/grpc_web/common/json_codec.ts
+++ b/src/protocol/grpc_web/common/json_codec.ts
@@ -83,7 +83,8 @@ export class GrpcWebJsonCodec implements GrpcWebCodec {
 }
 
 /**
- * A Codec that serializes/deserializes messages to and from JSON.
+ * A Codec that serializes/deserializes messages to and from JSON,
+ * using zipson for compression.
  */
  export class GrpcWebJsonWithZipsonCodec implements GrpcWebCodec {
   /** @override */

--- a/src/protocol/grpc_web/server/server.ts
+++ b/src/protocol/grpc_web/server/server.ts
@@ -159,6 +159,13 @@ export function registerGrpcWebRoutes<
         resp.sendStatus(HttpStatus.notAcceptable);
         return;
       }
+      
+      const contentEncoding = req.header('content-encoding');
+
+      if (codec.getContentEncoding() !== contentEncoding) {
+        resp.sendStatus(HttpStatus.notAcceptable);
+        return;
+      }
 
       try {
         // Get the encoded request context from the HTTP headers

--- a/src/protocol/server/server.ts
+++ b/src/protocol/server/server.ts
@@ -24,6 +24,7 @@ import { registerGrpcWebRoutes } from '../grpc_web/server/server';
 import { ModuleRpcContextServer } from '../../context/server';
 import { ModuleRpcCommon } from '../../common';
 import { ModuleRpcServer } from '../../server';
+import { GrpcWebCodec } from '../grpc_web/common/codec';
 
 export interface RpcServerOptions {
   /** The express router to start from.  By default, we start from `Router()`. */
@@ -38,7 +39,13 @@ export interface RpcServerOptions {
    * for a good overview).  To mitigate this we recommend, among other things, to use metadata
    * to pass "master" secrets (such as session secrets) around.
    */
-   useCompression?: boolean;
+  useCompression?: boolean;
+
+  /**
+   * The Codec to use.  By default, we use the [[GrpcWebJsonCodec]] codec.  The Codec must match
+   * the Codec used by the client (this is enforced through content-type negotiation).
+   */
+  codec?: GrpcWebCodec;
 }
 
 export function registerRpcRoutes<
@@ -89,6 +96,7 @@ export function registerRpcRoutes<
       router: options.router,
       reportError: options.captureError,
       useCompression: options.useCompression,
+      codec: options.codec
     },
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3602,3 +3602,8 @@ yn@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.0.tgz#fcbe2db63610361afcc5eb9e0ac91e976d046114"
   integrity sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==
+
+zipson@^0.2.12:
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/zipson/-/zipson-0.2.12.tgz#501f92e93f1c602ff908ad2c1c602e72746ecebb"
+  integrity sha512-+u+fyZQXJUJDTf4NGCChW+LoWGqCrhwHAfvtCtcmE0e40KmQt4YSP4l3TOay1WjRNv+VfODgBD/vNwaSSGnDwA==


### PR DESCRIPTION
This takes a stab at adding content encoding support (in accordance with the guidance [here](https://github.com/grpc/grpc-web/blob/master/doc/browser-features.md#compression)), and adds an example `GrpcWebJsonWithZipsonCodec`, which uses the [zipson](https://github.com/jgranstrom/zipson) library.
